### PR TITLE
fix koa peerDependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "supertest": "^3.0.0"
   },
   "peerDependencies": {
-    "koa": ">2"
+    "koa": "2.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
fixes yarn install warning
`warning " > koa-proxy@1.0.0-alpha.0" has incorrect peer dependency "koa@>2".`