### PR TITLE
FIX: npm tarball by using files field instead of .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .idea
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-test/
-docs/
-.npmignore
-.editorconfig
-.travis.yml
-.jshintrc

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5"
   },
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "koa",
     "middleware",


### PR DESCRIPTION
## The Problem

`koa-proxy@1.0.0-alpha.2` has the `.git` directory included in the npm tarball

```sh
> npm pack
npm notice
npm notice 📦  koa-proxy@1.0.0-alpha.2
npm notice === Tarball Contents ===
npm notice 845B  package.json
npm notice 1.4kB HISTORY.md
npm notice 4.5kB index.js
npm notice 2.1kB README.md
npm notice 1.2kB .git/index             <-------------------- ❌
```
Which causes the following issue:

```
> some-project > npm install
npm ERR! path /path/to/some-project/node_modules/koa-proxy
npm ERR! code EISGIT
npm ERR! git /path/to/some-project/koa-proxy: Appears to be a git repo or submodule.
npm ERR! git     /path/to/some-project/koa-proxy
```

## The fix
- use `files` field of package.json instead of `.npmignore` which is a better practise to handle npm tarball contents. Notice that `README.md`, `package.json` and `HISTORY.md` will be automatically included by default.
- so `.npmignore` removed
- `.gitignore`: ignores *.tgz files generated by `npm pack` 

## After

```sh
> npm pack
npm notice
npm notice 📦  koa-proxy@1.0.0-alpha.2
npm notice === Tarball Contents ===
npm notice 878B  package.json
npm notice 1.4kB HISTORY.md
npm notice 4.5kB index.js
npm notice 2.1kB README.md
```

Looks good.