### PR TITLE
Fix wrong/misleading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ app.use(proxy({
 }));
 ```
 
-Proxy won't send cookie to real server, you can set `jar = true` to send it.
+You can configure proxy to remember cookies for future use by setting `jar = true`. This means cookies set by server will be stored and resent in subsequent requests. For me info see the documentation for [request](https://github.com/request/request).
 
 ```js
 app.use(proxy({


### PR DESCRIPTION
The old documentation states that cookies will not be sent to origin server unless setting jar = true. This is wrong. Cookie (like other http headers) will ALWAYS be sent to origin server. Setting jar = true tells proxy to store cookies (in a jar, duh) and re-send them to server. 

See this [issue](https://github.com/edorivai/koa-proxy/issues/4) for more info