### PR TITLE
 Add option to asynchronously add request headers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ app.use(proxy({
 }));
 ```
 
+Asynchronously add headers to your request or override existing ones.
+```js
+app.use(proxy({
+  getOverrideRequestHeaders: async function() { 
+      return {
+          "cow": await asyncMoo(),
+      }
+  }
+}));
+```
+
 You can also add new headers to your response or override existing ones
 ```js
 app.use(proxy({

--- a/index.js
+++ b/index.js
@@ -16,6 +16,13 @@ module.exports = function(options) {
   return async function proxy(ctx, next) {
     var url = resolve(ctx.path, options);
 
+    var requestHeaders = options.getOverrideRequestHeaders
+      ? {
+        ...ctx.request.header,
+        ...await options.getOverrideRequestHeaders()
+      }
+      : ctx.request.header;
+
     if (typeof options.suppressRequestHeaders === 'object') {
       options.suppressRequestHeaders.forEach(function(h, i) {
         options.suppressRequestHeaders[i] = h.toLowerCase();
@@ -46,7 +53,7 @@ module.exports = function(options) {
     var opt = {
       jar: options.jar === true,
       url: url + (ctx.querystring ? '?' + ctx.querystring : ''),
-      headers: ctx.request.header,
+      headers: requestHeaders,      
       encoding: null,
       followRedirect: options.followRedirect === false ? false : true,
       method: ctx.method,

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(options) {
     var opt = {
       jar: options.jar === true,
       url: url + (ctx.querystring ? '?' + ctx.querystring : ''),
-      headers: requestHeaders,      
+      headers: requestHeaders,
       encoding: null,
       followRedirect: options.followRedirect === false ? false : true,
       method: ctx.method,

--- a/index.js
+++ b/index.js
@@ -17,10 +17,7 @@ module.exports = function(options) {
     var url = resolve(ctx.path, options);
 
     var requestHeaders = options.getOverrideRequestHeaders
-      ? {
-        ...ctx.request.header,
-        ...await options.getOverrideRequestHeaders()
-      }
+      ? Object.assign({}, ctx.request.header, await options.getOverrideRequestHeaders())
       : ctx.request.header;
 
     if (typeof options.suppressRequestHeaders === 'object') {


### PR DESCRIPTION
### Problem:
Needed to add authorization token to the request headers of proxied calls.  
### Resolution:
Added option to  asynchronously add or override request headers and updated documentation. 
