### PR TITLE
feat: introduce 'ignoreMethods' option for excluding some specific http method

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ app.use(proxy({
 }));
 ```
 
+You can use `ignoreMethods` to exclude some specific http method.
+
+```js
+app.use(proxy({
+  ignoreMethods: 'get' // or ['get', 'post', 'options'] case-insensitive
+}));
+```
+
 ## LICENSE
 
 Copyright (c) 2014 popomore. Licensed under the MIT license.

--- a/index.js
+++ b/index.js
@@ -41,6 +41,15 @@ module.exports = function(options) {
       }
     }
 
+    var ignoreMethods = typeof options.ignoreMethods === 'string' ? [options.ignoreMethods] : options.ignoreMethods;
+    if (ignoreMethods && Array.isArray(ignoreMethods)) {
+      ignoreMethods = ignoreMethods.map((it) => it.toLowerCase());
+
+      if (ignoreMethods.indexOf(ctx.method.toLowerCase()) > -1) {
+        return next();
+      }
+    }
+
     var parsedBody = getParsedBody(ctx);
 
     var opt = {


### PR DESCRIPTION
introduce 'ignoreMethods' option for excluding some specific http method